### PR TITLE
Refactor Model: simplify list/1 and rename opts to _opts

### DIFF
--- a/lib/beam_toolbox/model.ex
+++ b/lib/beam_toolbox/model.ex
@@ -4,21 +4,14 @@ defmodule BeamToolbox.Model do
       |> String.replace(" ", "-")
   end
 
-  defmacro __using__(opts) do
+  defmacro __using__(_opts) do
     quote do
       def list(data) do
-        list(data, [])
+        Enum.map(data, &(&1.name))
       end
 
       def find(data, expected_name) do
         Enum.find(data, fn(data) -> data.name == expected_name end)
-      end
-
-      defp list([data|rest], acc) do
-        list(rest, [data.name|acc])
-      end
-      defp list([], acc) do
-        Enum.reverse(acc)
       end
     end
   end


### PR DESCRIPTION
I noticed while watching the elixir sips episode where it was introduced that `Model.list/1` was just doing a map, and thought I'd suggest the simplification of just using `Enum.map/2`.

While I was there I noticed the compiler was warning about `opts` not being used, so I prefixed it with an underscore for the time being.
